### PR TITLE
Add extraEnvVars to the helm chart deployment

### DIFF
--- a/helm-charts/whitesource-renovate/templates/deployment.yaml
+++ b/helm-charts/whitesource-renovate/templates/deployment.yaml
@@ -26,6 +26,9 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            {{- with .Values.renovate.extraEnvVars }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- if .Values.renovate.acceptWhiteSourceTos }}
             - name: ACCEPT_WHITESOURCE_TOS
               value: {{ .Values.renovate.acceptWhiteSourceTos | quote }}

--- a/helm-charts/whitesource-renovate/values.yaml
+++ b/helm-charts/whitesource-renovate/values.yaml
@@ -7,6 +7,8 @@ nameOverride: ""
 fullnameOverride: ""
 
 renovate:
+  # Additional env vars
+  extraEnvVars: []
 
   # You must accept the WhiteSource Terms of Service to use the image.
   # Please read https://www.whitesourcesoftware.com/terms-of-service/


### PR DESCRIPTION
This allows to inject extra environment variables for the helm chart deployment.