### PR TITLE
Support for annotations in service

### DIFF
--- a/helm-charts/whitesource-renovate/templates/service.yaml
+++ b/helm-charts/whitesource-renovate/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
     helm.sh/chart: {{ include "whitesource-renovate.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm-charts/whitesource-renovate/values.yaml
+++ b/helm-charts/whitesource-renovate/values.yaml
@@ -74,6 +74,8 @@ renovate:
 service:
   type: ClusterIP
   port: 80
+  annotations: {}
+    # cloud.google.com/load-balancer-type: "Internal"
 
 ingress:
   enabled: false


### PR DESCRIPTION
In a mixed environment it is sometimes necessary to route traffic from Services inside the same (virtual) network address block.
It is useful to be able to set the service to annotations in that case.