### PR TITLE
docs: add redis

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -14,7 +14,7 @@ Essentially, it is an alternative to running the `renovate` CLI tool, with the f
 
 Logically, WhiteSource Renovate consists of four components:
 
-1.  In-memory DB
+1.  In-memory DB or Redis
     - Used for keeping the job queue and a list of known installations and repositories
 2.  Scheduler
     - Runs according to a `cron` schedule (defaults to hourly)


### PR DESCRIPTION
I'm not sure if it goes in this section and how exactly redis is used.
I thought it would be great to mention it this document.
According to https://docs.renovatebot.com/self-hosted-configuration/#redisurl it could be use instead of local cache? Or more?