### PR TITLE
fix(doc): update ref on the link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains Documentation, Release Notes and an Issue Tracker for W
 
 ## Documentation
 
-Please view [the markdown docs in this repository](https://github.com/whitesource/renovate-on-prem/tree/master/docs).
+Please view [the markdown docs in this repository](https://github.com/whitesource/renovate-on-prem/tree/main/docs).
 
 ## Download
 


### PR DESCRIPTION
GitHub redirects to main since the master branch is not the default branch for **whitesource/renovate-on-prem**.