### PR TITLE
feat: add existingSecret in helm template

### DIFF
--- a/helm-charts/whitesource-renovate/templates/_helpers.tpl
+++ b/helm-charts/whitesource-renovate/templates/_helpers.tpl
@@ -30,3 +30,25 @@ Create chart name and version as used by the chart label.
 {{- define "whitesource-renovate.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Expand the name of the default secret
+*/}}
+{{- define "whitesource-renovate.secret-name" -}}
+{{- if .Values.renovate.existingSecret -}}
+{{- .Values.renovate.existingSecret -}}
+{{- else -}}
+{{- include "whitesource-renovate.name" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Expand the name of the npmrc secret
+*/}}
+{{- define "whitesource-renovate.npmrc-secret-name" -}}
+{{- if .Values.renovate.npmrcExistingSecret -}}
+{{- .Values.renovate.npmrcExistingSecret -}}
+{{- else -}}
+{{- include "whitesource-renovate.name" . }}-npmrc
+{{- end -}}
+{{- end -}}

--- a/helm-charts/whitesource-renovate/templates/deployment.yaml
+++ b/helm-charts/whitesource-renovate/templates/deployment.yaml
@@ -76,15 +76,18 @@ spec:
                   name: {{ include "whitesource-renovate.secret-name" . }}
                   key: githubComToken
             {{- end }}
-            {{- if .Values.renovate.webhookSecret }}
+            {{- if or .Values.renovate.webhookSecret .Values.renovate.existingSecret }}
             - name: WEBHOOK_SECRET
-              value: {{ .Values.renovate.webhookSecret | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "whitesource-renovate.secret-name" . }}
+                  key: webhookSecret
             {{- end }}
             {{- if .Values.renovate.schedulerCron }}
             - name: SCHEDULER_CRON
               value: {{ .Values.renovate.schedulerCron | quote }}
             {{- end }}
-            {{- if .Values.renovate.pipIndexUrl }}
+            {{- if or .Values.renovate.pipIndexUrl .Values.renovate.existingSecret }}
             - name: PIP_INDEX_URL
               valueFrom:
                 secretKeyRef:

--- a/helm-charts/whitesource-renovate/templates/deployment.yaml
+++ b/helm-charts/whitesource-renovate/templates/deployment.yaml
@@ -33,11 +33,11 @@ spec:
             - name: ACCEPT_WHITESOURCE_TOS
               value: {{ .Values.renovate.acceptWhiteSourceTos | quote }}
             {{- end }}
-            {{- if .Values.renovate.licenseKey }}
+            {{- if or .Values.renovate.licenseKey .Values.renovate.existingSecret }}
             - name: LICENSE_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}
+                  name: {{ include "whitesource-renovate.secret-name" . }}
                   key: licenseKey
             {{- end }}
             {{- if .Values.renovate.renovatePlatform }}
@@ -48,32 +48,32 @@ spec:
             - name: RENOVATE_ENDPOINT
               value: {{ .Values.renovate.renovateEndpoint | quote }}
             {{- end }}
-            {{- if .Values.renovate.renovateToken }}
+            {{- if or .Values.renovate.renovateToken .Values.renovate.existingSecret }}
             - name: RENOVATE_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}
+                  name: {{ include "whitesource-renovate.secret-name" . }}
                   key: renovateToken
             {{- end }}
-            {{- if .Values.renovate.githubAppId }}
+            {{- if or .Values.renovate.githubAppId .Values.renovate.existingSecret }}
             - name: GITHUB_APP_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}
+                  name: {{ include "whitesource-renovate.secret-name" . }}
                   key: githubAppId
             {{- end }}
-            {{- if .Values.renovate.githubAppKey }}
+            {{- if or .Values.renovate.githubAppKey .Values.renovate.existingSecret }}
             - name: GITHUB_APP_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}
+                  name: {{ include "whitesource-renovate.secret-name" . }}
                   key: githubAppKey
             {{- end }}
-            {{- if .Values.renovate.githubComToken }}
+            {{- if or .Values.renovate.githubComToken .Values.renovate.existingSecret }}
             - name: GITHUB_COM_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}
+                  name: {{ include "whitesource-renovate.secret-name" . }}
                   key: githubComToken
             {{- end }}
             {{- if .Values.renovate.webhookSecret }}
@@ -88,7 +88,7 @@ spec:
             - name: PIP_INDEX_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}
+                  name: {{ include "whitesource-renovate.secret-name" . }}
                   key: pipIndexUrl
             {{- end }}
             {{- if .Values.renovate.noNodeTlsVerify }}
@@ -141,10 +141,10 @@ spec:
         - name: {{ .Release.Name }}-config-js-volume
           configMap:
             name: {{ .Release.Name }}-config-js
-        {{- if .Values.renovate.npmrc }}
+        {{- if or .Values.renovate.npmrc .Values.renovate.npmrcExistingSecret }}
         - name: {{ .Release.Name }}-npmrc-volume
           secret:
-            secretName: {{ .Release.Name }}-npmrc
+            secretName: {{ include "whitesource-renovate.npmrc-secret-name" . }}
         {{- end }}
         - name: {{ .Release.Name }}-cache-volume
           emptyDir: {}

--- a/helm-charts/whitesource-renovate/templates/secret.yaml
+++ b/helm-charts/whitesource-renovate/templates/secret.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.renovate.npmrc }}
+{{- if and .Values.renovate.npmrc (not .Values.renovate.npmrcExistingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-npmrc
+  name: {{- include "whitesource-renovate.npmrc-secret-name" . -}}
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
     helm.sh/chart: {{ include "whitesource-renovate.chart" . }}
@@ -14,10 +14,11 @@ data:
 
 ---
 
+{{- if not .Values.renovate.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ include "whitesource-renovate.secret-name" . }}
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
     helm.sh/chart: {{ include "whitesource-renovate.chart" . }}
@@ -45,3 +46,4 @@ data:
   {{- if .Values.renovate.pipIndexUrl }}
   pipIndexUrl: {{ .Values.renovate.pipIndexUrl | b64enc | quote }}
   {{- end}}
+{{- end }}

--- a/helm-charts/whitesource-renovate/values.yaml
+++ b/helm-charts/whitesource-renovate/values.yaml
@@ -41,6 +41,19 @@ renovate:
   # Optional, defaults to 'renovate'
   webhookSecret:
 
+  # PIP index url to get packages from. Will be mounted as a secret
+  pipIndexUrl:
+
+  # Existing secret with secret values with the following keys:
+  #   licenseKey:
+  #   renovateToken:
+  #   githubAppId:
+  #   githubAppKey:
+  #   githubComToken:
+  #   webhookSecret:
+  #   pipIndexUrl:
+  existingSecret:
+
   # Optional, defaults to '0 * * * *' (hourly)
   schedulerCron:
 
@@ -55,8 +68,9 @@ renovate:
   npmrc: # |
     # //registry.npmjs.org/:_authToken=xxxxxx
 
-  # PIP index url to get packages from. Will be mounted as a secret
-  pipIndexUrl:
+  # Existing secret with npmrc configuration with key:
+  #   .npmrc:
+  npmrcExistingSecret:
 
   # Disable NodeJS SSL verify (do not use for production)
   noNodeTlsVerify: false


### PR DESCRIPTION
Piggybacking off of https://github.com/whitesource/renovate-on-prem/pull/156, these are the changes that we're using. Had issues with original PR not passing helm linting and also having rendering issues with newlines. This PR appropriately renders now for `values.yaml` with and without existing secrets (both general and npmrc). 

Also added better documentation in the `values.yaml` for the existing secrets' expected keys for better UX.