### PR TITLE
feat: add extra volume and volumemount to helm template

### DIFF
--- a/helm-charts/whitesource-renovate/templates/deployment.yaml
+++ b/helm-charts/whitesource-renovate/templates/deployment.yaml
@@ -133,6 +133,9 @@ spec:
             {{- end }}
             - name: {{ .Release.Name }}-cache-volume
               mountPath: /tmp/renovate
+          {{- if ne (len .Values.extraVolumeMounts) 0 }}
+{{ toYaml .Values.extraVolumeMounts | indent 12 }}
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -148,6 +151,9 @@ spec:
         {{- end }}
         - name: {{ .Release.Name }}-cache-volume
           emptyDir: {}
+      {{- if ne (len .Values.extraVolumes) 0 }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+      {{- end }}
     {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/helm-charts/whitesource-renovate/templates/deployment.yaml
+++ b/helm-charts/whitesource-renovate/templates/deployment.yaml
@@ -134,7 +134,7 @@ spec:
             - name: {{ .Release.Name }}-cache-volume
               mountPath: /tmp/renovate
           {{- if ne (len .Values.extraVolumeMounts) 0 }}
-{{ toYaml .Values.extraVolumeMounts | indent 12 }}
+            {{ toYaml .Values.extraVolumeMounts | nindent 12 | trim }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -152,7 +152,7 @@ spec:
         - name: {{ .Release.Name }}-cache-volume
           emptyDir: {}
       {{- if ne (len .Values.extraVolumes) 0 }}
-{{ toYaml .Values.extraVolumes | indent 8 }}
+        {{ toYaml .Values.extraVolumes | nindent 8 | trim }}
       {{- end }}
     {{- with .Values.affinity }}
       affinity:

--- a/helm-charts/whitesource-renovate/values.yaml
+++ b/helm-charts/whitesource-renovate/values.yaml
@@ -96,3 +96,16 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+extraVolumes: []
+  # - name: secrets-store-inline
+  #   csi:
+  #     driver: secrets-store.csi.k8s.io
+  #     readOnly: true
+  #     volumeAttributes:
+  #       secretProviderClass: "some-secret-store"
+
+extraVolumeMounts: []
+  # - name: secrets-store-inline
+  #   mountPath: "/mnt/secrets-store"
+  #   readOnly: true


### PR DESCRIPTION
We ran into the use case where we're using Vault CSI and secrets won't get created without a volume to initiate the process. So submitting this PR to add the ability to add extra volumes as necessary. 