### PR TITLE
Allow cache directory to be moved to PVC

### DIFF
--- a/helm-charts/whitesource-renovate/templates/deployment.yaml
+++ b/helm-charts/whitesource-renovate/templates/deployment.yaml
@@ -153,7 +153,12 @@ spec:
             secretName: {{ include "whitesource-renovate.npmrc-secret-name" . }}
         {{- end }}
         - name: {{ .Release.Name }}-cache-volume
+          {{- if .Values.cachePersistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.cachePersistence.existingClaim | default (printf "%s-cache" (include "whitesource-renovate.fullname" .)) }}
+          {{- else }}
           emptyDir: {}
+          {{- end }}
       {{- if ne (len .Values.extraVolumes) 0 }}
         {{ toYaml .Values.extraVolumes | nindent 8 | trim }}
       {{- end }}

--- a/helm-charts/whitesource-renovate/templates/pvc.yaml
+++ b/helm-charts/whitesource-renovate/templates/pvc.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.cachePersistence.enabled (not .Values.cachePersistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ include "whitesource-renovate.fullname" . }}-cache
+  labels:
+    app.kubernetes.io/name: {{ include "whitesource-renovate.name" . }}
+    helm.sh/chart: {{ include "whitesource-renovate.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  accessModes:
+  {{- if not (empty .Values.cachePersistence.accessModes) }}
+  {{- range .Values.cachePersistence.accessModes }}
+    - {{ . | quote }}
+  {{- end }}
+  {{- else }}
+    - {{ .Values.cachePersistence.accessMode | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.cachePersistence.size | quote }}
+  {{- if .Values.cachePersistence.storageClass }}
+  {{- if (eq "-" .Values.cachePersistence.storageClass) }}
+    storageClassName: ""
+  {{- else }}
+    storageClassName: "{{ .Values.cachePersistence.storageClass }}"
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm-charts/whitesource-renovate/values.yaml
+++ b/helm-charts/whitesource-renovate/values.yaml
@@ -85,6 +85,25 @@ renovate:
   # Set log level, defaults to 'info'. Allowed values: fatal, error, warn, info, debug, trace
   logLevel: info
 
+## Cache Persistence Parameters
+## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
+##
+cachePersistence:
+  ## Enable persistence using Persistent Volume Claims
+  enabled: false
+  ## Persistent Volume storage class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner
+  storageClass: ""
+  ## @param Persistent Volume access modes
+  accessModes:
+    - ReadWriteOnce
+  ## Persistent Volume size
+  size: 1Gi
+  ## The name of an existing PVC to use for persistence
+  existingClaim: ""
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
This allows the cache dir to be moved to an PVC. This makes it possible to keep the cache on pod recreation.