### PR TITLE
feat: add pod annotations to helm chart

### DIFF
--- a/helm-charts/whitesource-renovate/Chart.yaml
+++ b/helm-charts/whitesource-renovate/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: whitesource-renovate
-version: 3.1.0
-appVersion: 1.2.0
+version: 3.1.1
+appVersion: 2.1.1
 description: Responsive Dependency Automation
 home: https://github.com/whitesource/renovate-on-prem
 sources:

--- a/helm-charts/whitesource-renovate/templates/deployment.yaml
+++ b/helm-charts/whitesource-renovate/templates/deployment.yaml
@@ -20,6 +20,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "whitesource-renovate.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       securityContext:
 {{ toYaml .Values.podSecurityContext | indent 8 }}


### PR DESCRIPTION
Add pod annotations to the helm chart. Our use case was adding kube2iam annotations for AWS IAM roles. 