### PR TITLE
fix npmrc-secret-name in helm chart

### DIFF
--- a/helm-charts/whitesource-renovate/templates/secret.yaml
+++ b/helm-charts/whitesource-renovate/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{- include "whitesource-renovate.npmrc-secret-name" . -}}
+  name: {{ include "whitesource-renovate.npmrc-secret-name" . }}
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
     helm.sh/chart: {{ include "whitesource-renovate.chart" . }}


### PR DESCRIPTION
Using the chart without npmrcExistingSecret resulted in an error because npmrc-secret metadata.name rendered from the template produces invalid yaml.

```
---
# Source: renovate/charts/whitesource-renovate/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name:whitesource-renovate-npmrclabels:   #<-------- missing space and newline
    app.kubernetes.io/name: RELEASE-NAME
    helm.sh/chart: whitesource-renovate-3.1.1
    app.kubernetes.io/instance: RELEASE-NAME
    app.kubernetes.io/managed-by: Helm
data:
```
