### PR TITLE
helm-chart: add .Release.Namespace to chart templates

### DIFF
--- a/helm-charts/whitesource-renovate/Chart.yaml
+++ b/helm-charts/whitesource-renovate/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: whitesource-renovate
-version: 3.1.1
-appVersion: 2.1.1
+version: 3.1.2
+appVersion: 2.5.1
 description: Responsive Dependency Automation
 home: https://github.com/whitesource/renovate-on-prem
 sources:

--- a/helm-charts/whitesource-renovate/templates/configmap.yaml
+++ b/helm-charts/whitesource-renovate/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-config-js
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
     helm.sh/chart: {{ include "whitesource-renovate.chart" . }}

--- a/helm-charts/whitesource-renovate/templates/deployment.yaml
+++ b/helm-charts/whitesource-renovate/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "whitesource-renovate.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "whitesource-renovate.name" . }}
     helm.sh/chart: {{ include "whitesource-renovate.chart" . }}

--- a/helm-charts/whitesource-renovate/templates/ingress.yaml
+++ b/helm-charts/whitesource-renovate/templates/ingress.yaml
@@ -5,6 +5,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "whitesource-renovate.name" . }}
     helm.sh/chart: {{ include "whitesource-renovate.chart" . }}

--- a/helm-charts/whitesource-renovate/templates/pvc.yaml
+++ b/helm-charts/whitesource-renovate/templates/pvc.yaml
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ include "whitesource-renovate.fullname" . }}-cache
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "whitesource-renovate.name" . }}
     helm.sh/chart: {{ include "whitesource-renovate.chart" . }}

--- a/helm-charts/whitesource-renovate/templates/secret.yaml
+++ b/helm-charts/whitesource-renovate/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "whitesource-renovate.npmrc-secret-name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}
     helm.sh/chart: {{ include "whitesource-renovate.chart" . }}

--- a/helm-charts/whitesource-renovate/templates/service.yaml
+++ b/helm-charts/whitesource-renovate/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "whitesource-renovate.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "whitesource-renovate.name" . }}
     helm.sh/chart: {{ include "whitesource-renovate.chart" . }}


### PR DESCRIPTION
When deploying with something like Spinnaker, there's no standard namespace assigned in the chart which can lead to default namespace deployment when not using something like `helm3` to generate. This adds the standard built-in object `.Release.Namespace` which inherits the namespace when passed in via helm CLI. So this will be a no-op for helm users, and this will appropriately source the value for third party manifest baking (like Spinnaker). 

This also bumps the helm chart version, and pins the correct app version (since we're now on 2.5.1 instead of 2.1.1)