### PR TITLE
Correction of required permissions for gitlab bot user

### DIFF
--- a/docs/configuration-gitlab.md
+++ b/docs/configuration-gitlab.md
@@ -33,7 +33,7 @@ In general, job priority is based on the probability that a user may be "waiting
 
 You should use a dedicated "bot account" for Renovate. Apart from reducing the chance of conflicts, it is better for teams if the actions they see from Renovate are clearly marked as coming from a dedicated bot account and not from a teammate's account, which could be confusing at times. e.g. did the bot automerge that PR, or did a human do it?
 
-If you are running your own instance of GitLab, it's suggested to name the account "Renovate Bot" with username "renovate-bot". Create this account and then create a Personal Access Token for it with `api`, `read_user` and `read_repository` permissions.
+If you are running your own instance of GitLab, it's suggested to name the account "Renovate Bot" with username "renovate-bot". Create this account and then create a Personal Access Token for it with `api`, `read_user` and `write_repository` permissions.
 
 It's best not add this bot account to any repositories yet.
 


### PR DESCRIPTION
According to my personal testing as well as the documentation in the renovate_runner project on gitlab indicates that the `write_repository` permission is required not just "read".